### PR TITLE
Proposal: Rename package to basp-purify

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: purify
+Source: basp-purify
 Section: science
 Priority: optional
 Maintainer: Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 8.0.0), cmake, greatcmakecookoff, libfftw3-dev,
 Standards-Version: 3.9.4
 Homepage: https://github.com/astro-informatics/purify
 
-Package: purify
+Package: basp-purify
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, sopt
 Description: collection of routines for radio interferometric imaging


### PR DESCRIPTION
The rename is done in response to [Ian Jaksons comment in the ITP bug](https://bugs.debian.org/830126#10) to avoid misunderstandings with the [Purify software by Rational](http://teamblue.unicomsi.com/products/purifyplus/). A clash is unprobable, since Rational Purify is propertiary, but many people (especially software developers) will be misguided by a "Purify" package.
"basp" is the prefix of the developer's research group.
